### PR TITLE
Mc_mini improvements

### DIFF
--- a/include/geometry/dataWindow.h
+++ b/include/geometry/dataWindow.h
@@ -1,45 +1,33 @@
 #pragma once
 
-#include <string>
 #include <iostream>
 #include <Eigen/Dense>
-#include <stdlib.h>
 
-using namespace Eigen;
-using namespace std;
-
-template<class T>
+template<typename T>
 class DataWindow {
   public:
-    DataWindow (T* _basePtr, unsigned int _columns, unsigned int _rows);
-    T& operator() (unsigned int _col, unsigned int _row);
-    const string displayMatrix();
+    DataWindow (T* basePtr = nullptr,
+		unsigned int columns = 0,
+		unsigned int rows = 0
+	        ) :
+		_basePtr(basePtr),
+		_cols(columns),
+		_rows(rows) 
+		{};
+		
+    T& operator() (unsigned int col, unsigned int row) 
+      {
+        // Column-major memory layout per Eigen.  
+	return _basePtr[row * _cols + col];
+      }
+    
+    void displayMatrix() 
+      {
+	std::cout << Eigen::Map<Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor> >(_basePtr, _rows, _cols).colwise().reverse();
+      }
+
   private:
-    T*           __basePtr;
-    unsigned int __cols;
-    unsigned int __rows;
+    T *const           _basePtr;
+    const unsigned int _cols;
+    const unsigned int _rows;
 };
-
-// Column-major data window, as per both Eigen and Visit.
-
-template<class T>
-DataWindow<T>::DataWindow (T* _basePtr, unsigned int _columns, unsigned int _rows) :
-    __basePtr (_basePtr),
-    __cols (_columns),
-    __rows (_rows) {};
-
-template<class T>
-T& DataWindow<T>::operator() (unsigned int _col, unsigned int _row) {
-	if (_row * __cols + _col < __cols * __rows )
-		return __basePtr[_row * __cols + _col];
-	else {
-		cout << "Out of bounds" << endl;
-		exit(-1);
-	}
-}
-
-template<class T>
-const string DataWindow<T>::displayMatrix() {
-  std::cout << Eigen::Map<Matrix<T, Dynamic, Dynamic, RowMajor> >(__basePtr, __rows, __cols).colwise().reverse();
-  return "";
-}

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -2,11 +2,6 @@
 #include <iomanip>
 #include <cassert>
 
-// First step in porting mc-mini from Eigen2 to Eigen3.
-// http://eigen.tuxfamily.org/dox/Eigen2ToEigen3.html
-
-#define EIGEN2_SUPPORT_STAGE10_FULL_EIGEN2_API true
-
 #include <Eigen/OrderingMethods>
 #include <Eigen/SparseCholesky>
 #include <Eigen/SparseQR>


### PR DESCRIPTION
This pull request offers two improvements:

I. The dataWindow class has been modified to reflect the current C++ capabilities. As a result, the code is more compact, intelligible, and safer. It is more compact by incorporating all function definitions and data initializations within the class definition body. It is more intelligible because redundant information has thus been removed. Finally, default arguments to the constructor make it safer in case a programmer forgets to supply one of the arguments to the constructor.

II.  Removed the message from main.cpp regarding porting the code from Eigen2 to Eigen3: it is irrelevant because the code has been using Eigen3 since the beginning. The assumption that the code is using Eigen2 is completely erroneous and this information may be a source of great confusion for new users of the code. In fact, the code will not compile with Eigen2, and realizing that Eigen3 is required for compilation may waste time of an uninformed user.